### PR TITLE
feat: Add collaborative documents with access control and persistence

### DIFF
--- a/apps/hocuspocus-server/src/index.ts
+++ b/apps/hocuspocus-server/src/index.ts
@@ -8,14 +8,26 @@ import { JWT_SECRET } from "@repo/backend-common/config";
 const server = Server.configure({
   port: 1234,
 
-  onAuthenticate: async ({ token }) => {
-  if (!token) throw new Error("Missing token");
-
-  const payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-  if (!payload?.userId) throw new Error("Invalid token");
-
-  console.log("🔐 Authenticated:", payload.userId);
-},
+  onAuthenticate: async ({ token, documentName }) => {
+    if (!token) throw new Error("Missing token");
+  
+    const payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
+    const userId = payload?.userId;
+  
+    const membership = await prismaClient.roomMembership.findFirst({
+      where: {
+        userId,
+        roomId: parseInt(documentName), // roomId is expected to be the same as documentName
+      },
+    });
+  
+    if (!membership) {
+      throw new Error("Access denied to this room");
+    }
+  
+    console.log(`✅ User ${userId} joined room ${documentName}`);
+  },
+  
 
 
   // 🧠 Save document content when it's updated

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -41,7 +41,13 @@ export default function Dashboard() {
 
     async function joinRoom() {
         setLoadingJoin(true);
-        const res = await fetch(`http://localhost:3001/room/${roomSlug}`);
+      const res = await fetch(`http://localhost:3001/room/${roomSlug}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${token}`,
+        }
+      });
         const data = await res.json();
         setLoadingJoin(false);
 

--- a/apps/web/app/room/[slug]/page.tsx
+++ b/apps/web/app/room/[slug]/page.tsx
@@ -3,7 +3,7 @@ import {Editor} from "../../../components/Editor";
 
 export default function RoomPage({ params }: { params: { slug: string } }) {
   return (
-    <Editor/>
+    <Editor docId={params.slug} />
     // <ChatRoomClient roomId={params.slug} />
   )
 }

--- a/apps/web/components/Editor.tsx
+++ b/apps/web/components/Editor.tsx
@@ -8,19 +8,21 @@ import StarterKit from "@tiptap/starter-kit";
 import { getToken } from "../hooks/useAuthToken";
 
 
-const docId = "default-doc";
-const token = getToken();
 
-const ydoc = new Y.Doc();
+export const Editor = ({ docId }: { docId: string }) => {
 
-const provider = new HocuspocusProvider({
-  url: 'ws://localhost:1234',
-  name: docId, 
-  document: ydoc,
-  token
-});
+  const token = getToken();
 
-export const Editor = () => {
+  const ydoc = new Y.Doc();
+
+  const provider = new HocuspocusProvider({
+    url: 'ws://localhost:1234',
+    name: docId,
+    document: ydoc,
+    token
+  });
+
+
   const editor = useEditor({
     immediatelyRender:false,
     extensions: [

--- a/packages/db/prisma/migrations/20250709073752_add_room_membership_and_doc_link/migration.sql
+++ b/packages/db/prisma/migrations/20250709073752_add_room_membership_and_doc_link/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[documentId]` on the table `Room` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Room" ADD COLUMN     "documentId" TEXT;
+
+-- CreateTable
+CREATE TABLE "RoomMembership" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "roomId" INTEGER NOT NULL,
+
+    CONSTRAINT "RoomMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomMembership_userId_roomId_key" ON "RoomMembership"("userId", "roomId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Room_documentId_key" ON "Room"("documentId");
+
+-- AddForeignKey
+ALTER TABLE "Room" ADD CONSTRAINT "Room_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomMembership" ADD CONSTRAINT "RoomMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomMembership" ADD CONSTRAINT "RoomMembership_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   password String
   rooms    Room[] @relation("RoomAdmin")
   chats    Chat[] @relation("UserChats")
+  memberships RoomMembership[]
 }
 
 model Room {
@@ -28,6 +29,9 @@ model Room {
   adminId Int
   admin   User   @relation("RoomAdmin", fields: [adminId], references: [id])
   chats   Chat[]
+  documentId  String?          @unique// FK to Document
+  document    Document?        @relation(fields: [documentId], references: [id])
+  members     RoomMembership[]
 }
 
 model Chat {
@@ -44,4 +48,15 @@ model Document {
   id        String   @id
   content   Bytes
   updatedAt DateTime @updatedAt
+  room      Room?    
+}
+
+model RoomMembership {
+  id      Int  @id @default(autoincrement())
+  user    User @relation(fields: [userId], references: [id])
+  userId  Int
+  room    Room @relation(fields: [roomId], references: [id])
+  roomId  Int
+
+  @@unique([userId, roomId])
 }


### PR DESCRIPTION
###  What’s in this PR:

- Implements collaborative rich-text editor with Tiptap + Hocuspocus
- Each room now has its own unique document
- Access is restricted via RoomMembership table
- Documents are stored persistently in PostgreSQL using Prisma
- Auth middleware improved with better error handling
- User is auto-joined to room on visit (membership is added)

###  What’s Next:

- Join only shows groups you have been part of
- Secret Code Sharing
- Dockerize
- Improve UI
